### PR TITLE
Mcp encoder type 1 appears to work better

### DIFF
--- a/Mobiflight/CORE_MCP_v17.2.mfmc
+++ b/Mobiflight/CORE_MCP_v17.2.mfmc
@@ -23,12 +23,12 @@
   <Button Name="CWSB" Pin="9" />
   <Button Name="DISENGAGE" Pin="25" />
   <Button Name="FDR" Pin="27" />
-  <Encoder Name="ENC_CRS_L" PinLeft="52" PinRight="53" EncoderType="0" />
-  <Encoder Name="ENC_IASMACH" PinLeft="37" PinRight="39" EncoderType="0" />
-  <Encoder Name="ENC_HEADING" PinLeft="32" PinRight="33" EncoderType="0" />
-  <Encoder Name="ENC_ALTITUDE" PinLeft="14" PinRight="15" EncoderType="0" />
-  <Encoder Name="ENC_VS" PinLeft="13" PinRight="12" EncoderType="0" />
-  <Encoder Name="ENC_CRS_R" PinLeft="26" PinRight="29" EncoderType="0" />
+  <Encoder Name="ENC_CRS_L" PinLeft="52" PinRight="53" EncoderType="1" />
+  <Encoder Name="ENC_IASMACH" PinLeft="37" PinRight="39" EncoderType="1" />
+  <Encoder Name="ENC_HEADING" PinLeft="32" PinRight="33" EncoderType="1" />
+  <Encoder Name="ENC_ALTITUDE" PinLeft="14" PinRight="15" EncoderType="1" />
+  <Encoder Name="ENC_VS" PinLeft="13" PinRight="12" EncoderType="1" />
+  <Encoder Name="ENC_CRS_R" PinLeft="26" PinRight="29" EncoderType="1" />
   <LedModule Name="MAX1" DinPin="46" ClsPin="47" ClkPin="48" Brightness="15" NumModules="1" />
   <LedModule Name="MAX2" DinPin="34" ClsPin="36" ClkPin="35" Brightness="15" NumModules="1" />
   <LedModule Name="MAX3" DinPin="31" ClsPin="30" ClkPin="28" Brightness="15" NumModules="1" />

--- a/Mobiflight/MSFS2020_PMDG737-700_MCP_v3.mcc
+++ b/Mobiflight/MSFS2020_PMDG737-700_MCP_v3.mcc
@@ -928,8 +928,8 @@
       <description>MSFS2020 R F/D</description>
       <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.6.0.0, Culture=neutral, PublicKeyToken=null" serial="CORE_MCP_v17/ SN-1dc-64c" name="FDR" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
-          <onPress type="MSFS2020CustomInputAction" command="40701 (&gt;K:ROTOR_BRAKE)" presetId="f0f814c6-9506-458c-a897-a999bdf93e31" />
-          <onRelease type="MSFS2020CustomInputAction" command="40701 (&gt;K:ROTOR_BRAKE)" presetId="f0f814c6-9506-458c-a897-a999bdf93e31" />
+          <onPress type="MSFS2020CustomInputAction" command="(L:ngx_MCP_FDRight,bool) ! if{ 40701 (&gt;K:ROTOR_BRAKE) }" presetId="a5c451c8-fb91-4faf-b2eb-5b0b864750a9" />
+          <onRelease type="MSFS2020CustomInputAction" command="(L:ngx_MCP_FDRight,bool) if{ 40701 (&gt;K:ROTOR_BRAKE) }" presetId="6cb9f96d-e1de-4de8-b180-2842183367eb" />
         </button>
         <preconditions />
         <configrefs />
@@ -940,8 +940,8 @@
       <description>MSFS2020 L F/D</description>
       <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.6.0.0, Culture=neutral, PublicKeyToken=null" serial="CORE_MCP_v17/ SN-1dc-64c" name="FDL" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
-          <onPress type="MSFS2020CustomInputAction" command="37801 (&gt;K:ROTOR_BRAKE)" presetId="cae7eba9-514d-48dc-b4c5-1fbba5dc9bb6" />
-          <onRelease type="MSFS2020CustomInputAction" command="37801 (&gt;K:ROTOR_BRAKE)" presetId="cae7eba9-514d-48dc-b4c5-1fbba5dc9bb6" />
+          <onPress type="MSFS2020CustomInputAction" command="(L:ngx_MCP_FDLeft,bool) ! if{ 37801 (&gt;K:ROTOR_BRAKE) }" presetId="241bdcb9-4c9e-4632-b5da-4fae32044641" />
+          <onRelease type="MSFS2020CustomInputAction" command="(L:ngx_MCP_FDLeft,bool) if{ 37801 (&gt;K:ROTOR_BRAKE) }" presetId="99c6200d-cc7f-4fe9-92a2-253a07501f19" />
         </button>
         <preconditions />
         <configrefs />
@@ -952,8 +952,8 @@
       <description>MSFS2020 AT/ARM</description>
       <settings msdata:InstanceType="MobiFlight.InputConfigItem, MFConnector, Version=9.6.0.0, Culture=neutral, PublicKeyToken=null" serial="CORE_MCP_v17/ SN-1dc-64c" name="AT" type="Button" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
         <button>
-          <onPress type="MSFS2020CustomInputAction" command="38001  (&gt;K:ROTOR_BRAKE)" presetId="08fd0f26-5151-40a9-8464-895fd35b69db" />
-          <onRelease type="MSFS2020CustomInputAction" command="38001  (&gt;K:ROTOR_BRAKE)" presetId="08fd0f26-5151-40a9-8464-895fd35b69db" />
+          <onPress type="MSFS2020CustomInputAction" command="(L:ngx_MCP_ATArm,bool) ! if{ 38001  (&gt;K:ROTOR_BRAKE) }" presetId="9f8ed3bc-de96-40c4-8c7c-e97180331c6a" />
+          <onRelease type="MSFS2020CustomInputAction" command="(L:ngx_MCP_ATArm,bool) if{ 38001  (&gt;K:ROTOR_BRAKE) }" presetId="9f693441-1419-4e1e-9e3c-6a2a2fe6f0d1" />
         </button>
         <preconditions />
         <configrefs>


### PR DESCRIPTION
This is a CoreFlight MCP I tested seems to have type 1 encoders, if the production units are the same hardware, then this should get rid of one missing click when you switch direction.